### PR TITLE
Fix broken writeup link in CTF dashboard + refactor page init

### DIFF
--- a/writeups/dashboard/index.html
+++ b/writeups/dashboard/index.html
@@ -6,7 +6,7 @@
   <title>AI Cy8er Command Center | EotW CTF SS CASE IT 2025</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body data-page="index" data-depth="0">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="js/data.js"></script>
   <script src="js/app.js"></script>
-  <script>
-    buildNav('index');
-    buildFooter();
-    renderOverview();
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/js/app.js
+++ b/writeups/dashboard/js/app.js
@@ -1,16 +1,17 @@
+// Path prefix from the page's depth relative to the dashboard root.
+// Overview (index.html) is depth 0; category pages under pages/ are depth 1.
+function rootPrefix() {
+  const depth = parseInt(document.body.dataset.depth || '0', 10);
+  return '../'.repeat(depth);
+}
+
 function buildNav(activePage) {
   const nav = document.getElementById('main-nav');
+  const prefix = rootPrefix();
   const links = [
     { href: 'index.html', label: 'Overview', id: 'index' },
-    ...CATEGORIES.map(c => ({
-      href: `pages/${c.id}.html`,
-      label: c.name,
-      id: c.id
-    }))
+    ...CATEGORIES.map(c => ({ href: `pages/${c.id}.html`, label: c.name, id: c.id }))
   ];
-
-  const isSubpage = location.pathname.includes('/pages/');
-  const prefix = isSubpage ? '../' : '';
 
   nav.innerHTML = `
     <div class="nav-inner">
@@ -24,17 +25,15 @@ function buildNav(activePage) {
 }
 
 function buildFooter() {
-  const footer = document.getElementById('main-footer');
-  footer.innerHTML = `AI Cy8er Command Center &mdash; EotW CTF SS CASE IT 2025`;
+  document.getElementById('main-footer').innerHTML =
+    `AI Cy8er Command Center &mdash; EotW CTF SS CASE IT 2025`;
 }
 
 function renderOverview() {
   const stats = getStats();
-  const app = document.getElementById('app');
-
   const solveRate = stats.total > 0 ? Math.round((stats.solved / stats.total) * 100) : 0;
 
-  app.innerHTML = `
+  document.getElementById('app').innerHTML = `
     <div class="hero">
       <h1>AI Cy8er Command Center</h1>
       <div class="subtitle">EotW CTF &bull; SS CASE IT 2025</div>
@@ -79,9 +78,9 @@ function renderCategoryPage(catId) {
   const cat = CATEGORIES.find(c => c.id === catId);
   if (!cat) return;
 
+  const prefix = rootPrefix();
   const challenges = getChallengesByCategory(catId);
   const app = document.getElementById('app');
-
   const diffClass = d => `badge badge-${d.toLowerCase()}`;
 
   if (challenges.length === 0) {
@@ -100,12 +99,15 @@ function renderCategoryPage(catId) {
     return;
   }
 
+  const solved = challenges.filter(c => c.solved).length;
+  const points = challenges.filter(c => c.solved).reduce((s, c) => s + c.points, 0);
+
   app.innerHTML = `
     <div class="page-header">
       <div class="page-icon">${cat.icon}</div>
       <div>
         <h1>${cat.name}</h1>
-        <p>${challenges.filter(c=>c.solved).length}/${challenges.length} solved &bull; ${challenges.filter(c=>c.solved).reduce((s,c)=>s+c.points,0)} pts</p>
+        <p>${solved}/${challenges.length} solved &bull; ${points} pts</p>
       </div>
     </div>
     <table class="challenge-table">
@@ -128,9 +130,21 @@ function renderCategoryPage(catId) {
             </td>
             <td><span class="points">${ch.points}</span></td>
             <td><span class="${diffClass(ch.difficulty)}">${ch.difficulty}</span></td>
-            <td>${ch.writeup ? `<a href="${ch.writeup}" class="writeup-link">[View]</a>` : '<span style="color:var(--text-muted)">--</span>'}</td>
+            <td>${ch.writeup ? `<a href="${prefix}${ch.writeup}" class="writeup-link">[View]</a>` : '<span style="color:var(--text-muted)">--</span>'}</td>
           </tr>
         `).join('')}
       </tbody>
     </table>`;
+}
+
+// Single entry point: each page sets <body data-page="..."> and calls initDashboard().
+function initDashboard() {
+  const page = document.body.dataset.page;
+  buildNav(page === 'index' ? 'index' : page);
+  buildFooter();
+  if (page === 'index') {
+    renderOverview();
+  } else {
+    renderCategoryPage(page);
+  }
 }

--- a/writeups/dashboard/js/data.js
+++ b/writeups/dashboard/js/data.js
@@ -23,6 +23,8 @@ const CHALLENGES = [
     points: 500,
     difficulty: "Hard",
     solved: true,
+    // Path is relative to the dashboard root (writeups/dashboard/); the
+    // renderer prepends the page-depth prefix so it resolves from any page.
     writeup: "../forensics/ai-command-center.md",
     summary: "Forensic analysis of an AI command and control infrastructure."
   }

--- a/writeups/dashboard/pages/crypto.html
+++ b/writeups/dashboard/pages/crypto.html
@@ -6,7 +6,7 @@
   <title>Cryptography | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="crypto" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('crypto');
-    buildFooter();
-    renderCategoryPage('crypto');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/forensics.html
+++ b/writeups/dashboard/pages/forensics.html
@@ -6,7 +6,7 @@
   <title>Forensics | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="forensics" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('forensics');
-    buildFooter();
-    renderCategoryPage('forensics');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/misc.html
+++ b/writeups/dashboard/pages/misc.html
@@ -6,7 +6,7 @@
   <title>Miscellaneous | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="misc" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('misc');
-    buildFooter();
-    renderCategoryPage('misc');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/osint.html
+++ b/writeups/dashboard/pages/osint.html
@@ -6,7 +6,7 @@
   <title>OSINT | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="osint" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('osint');
-    buildFooter();
-    renderCategoryPage('osint');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/pwn.html
+++ b/writeups/dashboard/pages/pwn.html
@@ -6,7 +6,7 @@
   <title>Binary Exploitation | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="pwn" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('pwn');
-    buildFooter();
-    renderCategoryPage('pwn');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/reversing.html
+++ b/writeups/dashboard/pages/reversing.html
@@ -6,7 +6,7 @@
   <title>Reverse Engineering | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="reversing" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('reversing');
-    buildFooter();
-    renderCategoryPage('reversing');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/stego.html
+++ b/writeups/dashboard/pages/stego.html
@@ -6,7 +6,7 @@
   <title>Steganography | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="stego" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('stego');
-    buildFooter();
-    renderCategoryPage('stego');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/web.html
+++ b/writeups/dashboard/pages/web.html
@@ -6,7 +6,7 @@
   <title>Web Exploitation | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="web" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('web');
-    buildFooter();
-    renderCategoryPage('web');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to #83, which merged the CTF dashboard but shipped a **broken writeup link**. This PR fixes that bug and refactors the page-init logic.

### Bug
Category pages live at `writeups/dashboard/pages/` and linked to the writeup via `../forensics/ai-command-center.md`, which resolves to `writeups/dashboard/forensics/…` (does not exist). The writeup is actually at `writeups/forensics/ai-command-center.md`.

### Fix + refactor
- Writeup paths are now stored relative to the dashboard root, and the renderer prepends a depth-based prefix — so links resolve correctly from both the overview page and category pages (now `../../forensics/ai-command-center.md`).
- Replaced the fragile `location.pathname.includes('/pages/')` prefix detection and the duplicated per-page inline scripts with a single `initDashboard()` entry point. Each page declares context via `<body data-page="…" data-depth="…">` — one source of truth instead of eight.

### Verification
- `node --check` on both JS files
- Stats logic confirmed (1 challenge / 500 pts)
- Headless DOM render of the overview, forensics (correct writeup href + solved badge), and an empty category (empty-state shown)
- Resolved link target confirmed to exist on disk

## Test plan
- [ ] Open `writeups/dashboard/index.html` — overview renders with stats and category cards
- [ ] Navigate to Forensics — the `[View]` writeup link opens `writeups/forensics/ai-command-center.md`
- [ ] Empty categories show the "No challenges recorded yet" state
- [ ] Nav highlights the active page on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTeL4g5NL6iv6WJkBv3XHZ)_