### PR TITLE
ci: target main instead of master in workflows

### DIFF
--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -29,8 +29,8 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Publish Packages as Release
       # this should not build anything, as they all should be built already
-      # however, it can fail if we push the tag before the merge-to-master build is complete, since that may publish
-      # so *always* wait for any merge-to-master to complete before publishing pkg-v* tags
+      # however, it can fail if we push the tag before the merge-to-main build is complete, since that may publish
+      # so *always* wait for any merge-to-main to complete before publishing pkg-v* tags
       run: |
         RELEASE_TAG=${GITHUB_REF#refs/tags/pkg-}
         echo "RELEASE_TAG=${RELEASE_TAG}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,10 @@
-# publish changes that are merged to master
+# publish changes that are merged to main
 name: Packages Push
 on:
   workflow_run:
     workflows: [LinuxKit CI]
     types: [completed]
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   packages:


### PR DESCRIPTION
## Summary

Switches the CI workflows over to `main` now that `master` is being retired.

- **`publish.yaml`** (Packages Push): the `workflow_run` trigger was filtered to `branches: [master, main]`; dropped `master` so it now fires only for `main`. Comment updated accordingly.
- **`package_release.yml`**: updated the descriptive comments that referenced the "merge-to-master" build to say "merge-to-main" (non-functional, doc only).

The other workflows need no change:
- **`ci.yml`** triggers on `[push, pull_request]` with no branch filter.
- **`release.yml`** and **`package_release.yml`** trigger on `create` (tag creation) with no branch filter.

## Notes
- I created the `main` branch (from `master`@`1e30fcd`) and pushed it. Changing the repository's **default branch** to `main` still has to be done in repo Settings → Branches by an admin — that can't be done from CI/git.
- Doc links in `ISSUE_TEMPLATE.md` / `PULL_REQUEST_TEMPLATE.md` point to `linuxkit/linuxkit/blob/master/...` (the upstream repo, which still uses `master`), so I left those untouched to avoid breaking the links.

## Verification
- `yaml.safe_load` parses both edited workflow files successfully.
- No remaining `master` references in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTeL4g5NL6iv6WJkBv3XHZ)_