### PR TITLE
docs: refer to main branch instead of master

### DIFF
--- a/docs/alpine-base-update.md
+++ b/docs/alpine-base-update.md
@@ -33,7 +33,7 @@ since the push out can be slow and require retries, we try to make all of the ch
 
 ### Preparation
 
-As a starting point you have to be on the update to date master branch
+As a starting point you have to be on the update to date main branch
 and be in the root directory of your local git clone. You should also
 have the same setup on all build machines used.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,7 @@ clone (in my setup the official LinuxKit repository is available as
 `upstream` remote). If your setup is different, you may have to adjust
 some of the commands below.
 
-As a starting point you have to be on the update to date master branch
+As a starting point you have to be on the update to date main branch
 and be in the root directory of your local git clone. You should also
 have the same setup on all build machines used.
 


### PR DESCRIPTION
## Summary

Updates the two developer-facing docs that instruct contributors to start from the `master` branch, now that `main` is the default branch.

- `docs/releasing.md` — "be on the update to date **master** branch" → **main**
- `docs/alpine-base-update.md` — same change

These were the only references to **this repo's own** `master` branch outside the CI workflows. All other `master` occurrences were deliberately left untouched, as they point to upstream/external repositories (`linuxkit/linuxkit`, qemu, moby, opencontainers, golangci-lint, etc.) whose default branch is still `master`, or are the `@masterzen` username in archival reports, or vendored third-party code.

## Verification
- `git grep` confirms no remaining references to this repo's own `master` branch in tracked, non-vendored files outside the workflows (already handled in #85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTeL4g5NL6iv6WJkBv3XHZ)_