### PR TITLE
Implement three suggestions: Kali Pritom support, CTF dashboard link fix, master→main migration

### DIFF
--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -29,8 +29,8 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Publish Packages as Release
       # this should not build anything, as they all should be built already
-      # however, it can fail if we push the tag before the merge-to-master build is complete, since that may publish
-      # so *always* wait for any merge-to-master to complete before publishing pkg-v* tags
+      # however, it can fail if we push the tag before the merge-to-main build is complete, since that may publish
+      # so *always* wait for any merge-to-main to complete before publishing pkg-v* tags
       run: |
         RELEASE_TAG=${GITHUB_REF#refs/tags/pkg-}
         echo "RELEASE_TAG=${RELEASE_TAG}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,10 @@
-# publish changes that are merged to master
+# publish changes that are merged to main
 name: Packages Push
 on:
   workflow_run:
     workflows: [LinuxKit CI]
     types: [completed]
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   packages:

--- a/contrib/android-kali/README.md
+++ b/contrib/android-kali/README.md
@@ -1,0 +1,155 @@
+# Kali Linux on Android (NetHunter Chroot)
+
+Scripts for setting up a Kali Linux environment on ARM64 Android tablets
+(e.g. Pritom Tab10 Max M10-R02, Android 14) using Termux + proot/chroot.
+
+This is **Option B** from [`docs/platform-pritom-tablet.md`](../../docs/platform-pritom-tablet.md)
+and does **not** require an unlocked bootloader. Android continues to run normally.
+
+## Quick Start
+
+1. Install **Termux** from [F-Droid](https://f-droid.org/en/packages/com.termux/)
+   (not from Google Play)
+
+2. Open Termux and run:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/marcelraschke/linuxkit/main/contrib/android-kali/nethunter-setup.sh | bash
+   ```
+
+3. Enter the Kali environment:
+   ```bash
+   kali
+   ```
+
+## Options
+
+| Flag              | Description                                                       |
+|-------------------|-------------------------------------------------------------------|
+| `--check`         | Run diagnostics (arch, storage, network, root) without installing |
+| `--minimal`       | Download minimal rootfs (~200MB) instead of full (~1.5GB)         |
+| `--tools`         | Install `kali-tools-top10` during setup                           |
+| `--vnc`           | Configure VNC server for graphical desktop (XFCE4)               |
+| `--root`          | Use native chroot instead of proot (requires Magisk)              |
+| `--wifi-monitor`  | Install WiFi monitor-mode helpers `wmon`/`wmon-off` (needs root)  |
+
+Flags can be combined freely:
+
+```bash
+# Minimal base, no extra tools
+bash nethunter-setup.sh --minimal
+
+# Full install with security tools and graphical desktop
+bash nethunter-setup.sh --tools --vnc
+
+# Root chroot with WiFi monitor mode support
+bash nethunter-setup.sh --root --tools --wifi-monitor
+```
+
+## Directory Structure
+
+```
+contrib/android-kali/
+├── README.md               # This file
+├── nethunter-setup.sh      # Automated setup script
+└── kali-boot.sh            # Termux:Boot script for auto-start on device boot
+```
+
+## Root Mode (Magisk)
+
+`--root` uses a native chroot with full kernel access (raw sockets, WiFi monitor
+mode, iptables). It requires [Magisk](https://github.com/topjohnwu/Magisk/releases)
+and a Termux root grant.
+
+**Before running `--root`, grant Termux root access:**
+
+1. Open **Magisk** → tap the **Superuser** tab (shield icon)
+2. In Termux, run `su` — a Magisk popup appears → tap **Grant**
+3. Check **Remember choice** to avoid repeated prompts
+4. Verify: `su -c "id"` → should print `uid=0(root) ...`
+
+Then run the setup:
+
+```bash
+bash nethunter-setup.sh --root --tools
+```
+
+If `su -c "id"` fails after granting, try `pkg install tsu` and grant `tsu`
+in the Superuser tab as well. See
+[Root Mode with Magisk](../../docs/platform-pritom-tablet.md#root-mode-with-magisk)
+for full Magisk installation steps and a troubleshooting table.
+
+## Requirements
+
+- Termux from F-Droid (v0.118+)
+- 4 GB free storage (2 GB for `--minimal`)
+- Internet connection for initial download
+- Root (Magisk) only required for `--root` mode
+
+## What the Script Does
+
+1. Updates Termux packages and installs `proot` / `proot-distro`
+2. Downloads the official Kali Linux ARM64 rootfs from `kali.download`
+3. Extracts it to `~/kali-arm64/`
+4. Configures DNS, hostname, and `.bashrc`
+5. Creates a `kali` launch command in `$PREFIX/bin/kali`
+
+## After Setup
+
+```bash
+# Enter Kali shell
+kali
+
+# Install additional tools (inside Kali)
+apt-get update && apt-get install nmap wireshark-cli metasploit-framework
+
+# Start SSH server (inside Kali)
+service ssh start
+
+# Start VNC desktop (if --vnc was used)
+kali --vnc
+# Connect with a VNC client to <tablet-ip>:5901
+# VNC password is printed at the end of setup — change with: kali vncpasswd
+
+# WiFi monitor mode (if --wifi-monitor was used, inside Kali)
+wmon wlan1 6      # enable on wlan1, channel 6
+airodump-ng wlan1
+wmon-off wlan1    # restore managed mode
+```
+
+## Cleanup / Unmount (root mode only)
+
+When using `--root`, filesystems are bind-mounted and auto-unmounted on exit.
+If Kali crashes or the session is lost without a clean exit:
+
+```bash
+# Force-unmount all Kali bind mounts
+kali-stop
+```
+
+## Auto-Start on Boot (Termux:Boot)
+
+Install [Termux:Boot](https://f-droid.org/en/packages/com.termux.boot/) from
+F-Droid to launch Kali services automatically when the tablet starts:
+
+```bash
+# Create the Termux:Boot directory
+mkdir -p ~/.termux/boot
+
+# Create an autostart script (starts Kali SSH on boot)
+cat > ~/.termux/boot/kali-boot.sh <<'EOF'
+#!/data/data/com.termux/files/usr/bin/bash
+# Auto-start Kali SSH server on device boot
+termux-wake-lock
+kali service ssh start
+EOF
+chmod +x ~/.termux/boot/kali-boot.sh
+```
+
+Open the **Termux:Boot** app once after install to activate it, then reboot
+to verify the script runs automatically.
+
+## See Also
+
+- [`docs/platform-pritom-tablet.md`](../../docs/platform-pritom-tablet.md) — Full platform documentation
+- [`examples/kali-pritom-tablet.yml`](../../examples/kali-pritom-tablet.yml) — LinuxKit native boot configuration
+- [Kali NetHunter documentation](https://www.kali.org/docs/nethunter/)

--- a/contrib/android-kali/kali-boot.sh
+++ b/contrib/android-kali/kali-boot.sh
@@ -1,0 +1,116 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# =============================================================================
+# kali-boot.sh — Termux:Boot script for auto-starting Kali services
+# =============================================================================
+#
+# INSTALL:
+#   1. Install Termux:Boot from F-Droid (NOT Google Play)
+#   2. Open the Termux:Boot app once to activate it as a boot receiver
+#   3. Copy this script into ~/.termux/boot/ :
+#
+#        mkdir -p ~/.termux/boot
+#        cp kali-boot.sh ~/.termux/boot/
+#        chmod +x ~/.termux/boot/kali-boot.sh
+#
+#   4. Reboot the tablet — this script runs automatically after boot
+#
+# REQUIREMENTS:
+#   - Termux from F-Droid (v0.118+)
+#   - Kali chroot set up via nethunter-setup.sh (creates the 'kali' command)
+#   - termux-api package for wake-lock: pkg install termux-api
+#
+# CUSTOMIZATION:
+#   Edit the "User configuration" section below to enable/disable services.
+# =============================================================================
+
+# ---- User configuration -----------------------------------------------------
+
+# Keep the CPU awake so services are not killed by Android's battery saver.
+# Requires: pkg install termux-api
+ENABLE_WAKE_LOCK=true
+
+# Seconds to wait after boot before starting services.
+# Android's networking stack needs time to initialize.
+BOOT_DELAY=15
+
+# Start the Kali SSH server on boot (recommended).
+# Connect over USB tethering or WiFi: ssh -p 2222 root@<tablet-ip>
+#
+# SECURITY WARNING: SSH starts with PasswordAuthentication=yes and
+# PermitRootLogin=yes. Before exposing the tablet to any network, set
+# a strong root password inside Kali:
+#   kali passwd root
+#
+# RECOMMENDED: Switch to key-based authentication to disable passwords.
+# Inside Kali, add your public key once, then disable password auth:
+#   mkdir -p /root/.ssh && chmod 700 /root/.ssh
+#   echo "ssh-ed25519 AAAA... yourkey" >> /root/.ssh/authorized_keys
+#   chmod 600 /root/.ssh/authorized_keys
+# Then change the sshd line below to add: -o "PasswordAuthentication no"
+START_SSH=true
+SSH_PORT=2222
+
+# Start a VNC server on boot for graphical desktop access.
+# Requires: nethunter-setup.sh --vnc
+# Connect with any VNC client to <tablet-ip>:5901, password set via 'vncpasswd'
+START_VNC=false
+VNC_GEOMETRY="1280x800"
+VNC_DEPTH=24
+VNC_DISPLAY=":1"
+
+# Log file for boot-time output (useful for debugging startup issues).
+LOGFILE="${HOME}/.kali-boot.log"
+
+# ---- Boot sequence ----------------------------------------------------------
+
+exec >> "$LOGFILE" 2>&1
+echo ""
+echo "=== Kali boot script started: $(date) ==="
+
+if $ENABLE_WAKE_LOCK; then
+  if command -v termux-wake-lock &>/dev/null; then
+    termux-wake-lock
+    echo "[OK] Wake lock acquired"
+  else
+    echo "[WW] termux-wake-lock not found — install: pkg install termux-api"
+  fi
+fi
+
+if ! [[ "$BOOT_DELAY" =~ ^[0-9]+$ ]]; then
+  echo "[!!] BOOT_DELAY must be a non-negative integer (got: '${BOOT_DELAY}') — using 15s"
+  BOOT_DELAY=15
+fi
+echo "[*] Waiting ${BOOT_DELAY}s for Android to initialize networking..."
+sleep "$BOOT_DELAY"
+
+# Verify the 'kali' launcher exists before attempting to start services
+if ! command -v kali &>/dev/null; then
+  echo "[!!] 'kali' command not found — run nethunter-setup.sh first"
+  exit 1
+fi
+
+if $START_SSH; then
+  echo "[*] Starting Kali SSH server on port ${SSH_PORT}..."
+  kali /usr/sbin/sshd -p "${SSH_PORT}" \
+    -o "PermitRootLogin yes" \
+    -o "PasswordAuthentication yes" \
+    -o "PrintLastLog no" && \
+    echo "[OK] SSH started" || \
+    echo "[!!] SSH failed to start"
+fi
+
+if $START_VNC; then
+  echo "[*] Starting Kali VNC server ${VNC_DISPLAY} (${VNC_GEOMETRY})..."
+  kali vncserver "${VNC_DISPLAY}" \
+    -geometry "${VNC_GEOMETRY}" \
+    -depth "${VNC_DEPTH}" \
+    -localhost no && \
+    echo "[OK] VNC started on display ${VNC_DISPLAY}" || \
+    echo "[!!] VNC failed to start"
+fi
+
+# Print current IP addresses for reference
+echo "[*] Network addresses:"
+ip -4 addr show 2>/dev/null | grep "inet " | awk '{print "    " $2 "  (" $NF ")"}'
+
+echo "=== Boot sequence complete: $(date) ==="

--- a/contrib/android-kali/nethunter-setup.sh
+++ b/contrib/android-kali/nethunter-setup.sh
@@ -1,0 +1,760 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Kali NetHunter Chroot Setup for Pritom Tab10 Max M10-R02 (Android 14)
+# ============================================================================
+#
+# This script sets up a Kali Linux chroot/proot environment on an Android
+# tablet using Termux. No root required for proot mode; root unlocks full
+# chroot mode with better hardware access.
+#
+# USAGE (run inside Termux on the tablet):
+#   curl -fsSL https://raw.githubusercontent.com/.../nethunter-setup.sh | bash
+#   # or after copying to the tablet:
+#   bash nethunter-setup.sh [--root]
+#
+# OPTIONS:
+#   --check         Run prerequisite diagnostics without installing anything
+#   --root          Use native chroot (requires root / Magisk)
+#   --wifi-monitor  Configure WiFi monitor mode (only with --root, needs compatible adapter)
+#   --tools         Install Kali security tools after setup (needs network)
+#   --vnc           Install VNC server for graphical desktop access
+#   --minimal       Download minimal rootfs (~200MB) instead of full (~1.5GB)
+#   --help          Show this help
+#
+# REQUIREMENTS:
+#   - Termux installed from F-Droid (NOT Google Play — Play version is outdated)
+#   - At least 4 GB free storage for base install
+#   - Internet connection during initial setup
+#
+# ============================================================================
+
+set -euo pipefail
+
+# ---- Configuration ---------------------------------------------------------
+
+KALI_ROOTFS_URL_ARM64="https://kali.download/nethunter-images/current/rootfs/kalifs-arm64-full.tar.xz"
+KALI_ROOTFS_URL_ARM64_MINIMAL="https://kali.download/nethunter-images/current/rootfs/kalifs-arm64-minimal.tar.xz"
+KALI_INSTALL_DIR="${HOME}/kali-arm64"
+KALI_LAUNCH_SCRIPT="${PREFIX}/bin/kali"
+USE_ROOT=false
+INSTALL_TOOLS=false
+INSTALL_VNC=false
+INSTALL_MINIMAL=false
+SETUP_WIFI_MONITOR=false
+CHECK_ONLY=false
+KALI_STOP_SCRIPT="${PREFIX}/bin/kali-stop"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# ---- Argument parsing -------------------------------------------------------
+
+for arg in "$@"; do
+  case "$arg" in
+    --root)          USE_ROOT=true ;;
+    --wifi-monitor)  SETUP_WIFI_MONITOR=true ;;
+    --tools)         INSTALL_TOOLS=true ;;
+    --vnc)           INSTALL_VNC=true ;;
+    --minimal)       INSTALL_MINIMAL=true ;;
+    --check)         CHECK_ONLY=true ;;
+    --help|-h)
+      sed -n '3,30p' "$0"
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown option: $arg${NC}"
+      exit 1
+      ;;
+  esac
+done
+
+# ---- Helper functions -------------------------------------------------------
+
+info()    { echo -e "${BLUE}[*]${NC} $*"; }
+success() { echo -e "${GREEN}[+]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[!]${NC} $*"; }
+error()   { echo -e "${RED}[-]${NC} $*"; exit 1; }
+
+# ---- Diagnostic check (--check) --------------------------------------------
+
+run_check() {
+  local ok=true
+  echo ""
+  echo -e "${BLUE}== Kali NetHunter Setup Diagnostics ==${NC}"
+  echo ""
+
+  # Termux
+  if [ -n "${PREFIX:-}" ] && [ -d "$PREFIX" ]; then
+    echo -e "${GREEN}[OK]${NC}  Termux detected           $PREFIX"
+  else
+    echo -e "${RED}[!!]${NC}  Termux not detected       Install Termux from F-Droid"
+    ok=false
+  fi
+
+  # Architecture
+  local arch
+  arch=$(uname -m)
+  if [ "$arch" = "aarch64" ]; then
+    echo -e "${GREEN}[OK]${NC}  Architecture              $arch (ARM64)"
+  else
+    echo -e "${YELLOW}[!!]${NC}  Architecture              $arch (expected aarch64)"
+    ok=false
+  fi
+
+  # Storage
+  local avail
+  avail=$(df -BG "${HOME}" 2>/dev/null | awk 'NR==2{print $4}' | tr -d 'G')
+  if [ "${avail:-0}" -ge 4 ]; then
+    echo -e "${GREEN}[OK]${NC}  Free storage              ${avail}GB (≥4GB required)"
+  else
+    echo -e "${YELLOW}[WW]${NC}  Free storage              ${avail}GB (4GB recommended)"
+  fi
+
+  # Required commands
+  for cmd in curl tar; do
+    if command -v "$cmd" &>/dev/null; then
+      echo -e "${GREEN}[OK]${NC}  Command available         $cmd"
+    else
+      echo -e "${RED}[!!]${NC}  Command missing           $cmd  →  pkg install $cmd"
+      ok=false
+    fi
+  done
+
+  # proot (not needed in --root / native chroot mode)
+  if command -v proot &>/dev/null; then
+    echo -e "${GREEN}[OK]${NC}  proot available           $(proot --version 2>&1 | head -1)"
+  elif ! $USE_ROOT; then
+    echo -e "${YELLOW}[WW]${NC}  proot not installed       →  pkg install proot"
+  else
+    echo -e "${BLUE}[--]${NC}  proot not installed       (not needed in --root mode)"
+  fi
+
+  # Existing rootfs
+  if [ -d "${KALI_INSTALL_DIR}/usr" ]; then
+    local sz
+    sz=$(du -sh "${KALI_INSTALL_DIR}" 2>/dev/null | cut -f1)
+    echo -e "${GREEN}[OK]${NC}  Kali rootfs exists        ${KALI_INSTALL_DIR} (${sz})"
+  else
+    echo -e "${BLUE}[--]${NC}  Kali rootfs not present   (will be downloaded on setup)"
+  fi
+
+  # kali launch script
+  if [ -x "${KALI_LAUNCH_SCRIPT}" ]; then
+    echo -e "${GREEN}[OK]${NC}  Launch script exists      $KALI_LAUNCH_SCRIPT"
+  else
+    echo -e "${BLUE}[--]${NC}  Launch script missing     (created during setup)"
+  fi
+
+  # Root / su
+  if command -v su &>/dev/null; then
+    if su -c "id" &>/dev/null 2>&1; then
+      echo -e "${GREEN}[OK]${NC}  Root access (Magisk)      $(su -c "id" 2>/dev/null | cut -d' ' -f1)"
+    else
+      echo -e "${YELLOW}[WW]${NC}  su found but access denied  Grant in Magisk → Superuser tab"
+    fi
+  else
+    echo -e "${BLUE}[--]${NC}  su not found              (only needed for --root mode)"
+  fi
+
+  # Network
+  if curl -fsS --max-time 5 https://kali.download/ -o /dev/null 2>/dev/null; then
+    echo -e "${GREEN}[OK]${NC}  Network reachable         kali.download"
+  else
+    echo -e "${YELLOW}[WW]${NC}  kali.download unreachable (check internet connection)"
+  fi
+
+  # WiFi interfaces
+  echo ""
+  echo -e "${BLUE}[*]${NC}  WiFi interfaces:"
+  if command -v iw &>/dev/null; then
+    iw dev 2>/dev/null | grep -E "Interface|type" | sed 's/^/      /' || echo "      (none found)"
+  else
+    ip link show 2>/dev/null | grep -E "wlan|wlp" | sed 's/^/      /' || echo "      (iw not installed: pkg install iw)"
+  fi
+
+  # IP addresses
+  echo ""
+  echo -e "${BLUE}[*]${NC}  Network addresses:"
+  ip -4 addr show 2>/dev/null | grep "inet " | \
+    awk '{print "      "$2 "  (" $NF ")"}' || echo "      (none)"
+
+  echo ""
+  if $ok; then
+    echo -e "${GREEN}All checks passed. Ready to run: bash nethunter-setup.sh${NC}"
+  else
+    echo -e "${YELLOW}Some checks failed — review items marked [!!] above.${NC}"
+  fi
+  echo ""
+}
+
+check_termux() {
+  if [ -z "${PREFIX:-}" ] || [ ! -d "$PREFIX" ]; then
+    error "This script must be run inside Termux. Install Termux from F-Droid."
+  fi
+  info "Termux detected: $PREFIX"
+}
+
+check_storage() {
+  local avail
+  avail=$(df -BG "$HOME" | awk 'NR==2 {print $4}' | tr -d 'G')
+  if [ "${avail:-0}" -lt 4 ]; then
+    warn "Available storage: ${avail}GB — at least 4GB recommended"
+    read -rp "Continue anyway? [y/N] " confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || exit 0
+  fi
+  success "Storage check passed (${avail}GB available)"
+}
+
+check_root() {
+  if $USE_ROOT; then
+    if ! command -v su &>/dev/null; then
+      error "'su' not found — Magisk is not installed or not active.
+  Install Magisk: https://github.com/topjohnwu/Magisk/releases
+  Then open Termux, run 'su' to trigger the grant popup, and tap Grant.
+  Re-run this script once root is confirmed: bash nethunter-setup.sh --root"
+    fi
+    if ! su -c "id" &>/dev/null 2>&1; then
+      error "Root access denied. To fix:
+  1. Open the Magisk app
+  2. Tap the Superuser tab (shield icon)
+  3. Find Termux in the list and set it to Allow
+     -- OR -- open Termux, run 'su', and tap Grant in the popup
+  4. Verify with: su -c \"id\"  (should print uid=0)
+  5. Re-run: bash nethunter-setup.sh --root"
+    fi
+    success "Root access confirmed ($(su -c "id" 2>/dev/null | cut -d' ' -f1))"
+  fi
+}
+
+install_termux_deps() {
+  info "Updating Termux packages..."
+  pkg update -y -o Dpkg::Options::="--force-confnew" 2>/dev/null || true
+
+  local deps=(curl wget tar proot proot-distro)
+  if $USE_ROOT; then
+    deps=(curl wget tar)
+  fi
+
+  info "Installing dependencies: ${deps[*]}"
+  pkg install -y "${deps[@]}" 2>/dev/null || \
+    apt-get install -y "${deps[@]}" 2>/dev/null || \
+    error "Failed to install dependencies. Run 'pkg update' manually first."
+
+  if $INSTALL_VNC; then
+    info "Installing VNC dependencies..."
+    pkg install -y tigervnc x11-repo 2>/dev/null || true
+    pkg install -y xfce4 2>/dev/null || \
+      warn "XFCE4 install failed — VNC will use basic window manager"
+  fi
+
+  success "Termux dependencies installed"
+}
+
+# ---- Rootfs download --------------------------------------------------------
+
+download_kali_rootfs() {
+  local url
+  if $INSTALL_MINIMAL; then
+    url="$KALI_ROOTFS_URL_ARM64_MINIMAL"
+    info "Downloading Kali Linux ARM64 minimal rootfs..."
+  else
+    url="$KALI_ROOTFS_URL_ARM64"
+    info "Downloading Kali Linux ARM64 full rootfs (~1.5GB)..."
+  fi
+
+  local tarball="${TMPDIR:-/tmp}/kali-rootfs.tar.xz"
+
+  if [ -f "$tarball" ]; then
+    info "Existing tarball found, verifying..."
+    if ! file "$tarball" | grep -q 'XZ compressed\|gzip compressed'; then
+      warn "Corrupt tarball detected, re-downloading..."
+      rm -f "$tarball"
+    fi
+  fi
+
+  if [ ! -f "$tarball" ]; then
+    curl -L --retry 5 --retry-delay 3 --progress-bar -o "$tarball" "$url" || \
+      wget -O "$tarball" "$url" || \
+      error "Failed to download Kali rootfs. Check your internet connection."
+  fi
+
+  info "Extracting Kali rootfs to $KALI_INSTALL_DIR ..."
+  mkdir -p "$KALI_INSTALL_DIR"
+  if $USE_ROOT; then
+    # proot is not installed in root mode — use plain tar directly
+    tar -xJf "$tarball" -C "$KALI_INSTALL_DIR" \
+      --exclude='dev' 2>/dev/null || \
+      error "Extraction failed."
+  else
+    proot --link2symlink tar -xJf "$tarball" -C "$KALI_INSTALL_DIR" \
+      --exclude='dev' 2>/dev/null || \
+      tar -xJf "$tarball" -C "$KALI_INSTALL_DIR" \
+        --exclude='dev' 2>/dev/null || \
+      error "Extraction failed."
+  fi
+
+  rm -f "$tarball"
+  success "Kali rootfs extracted"
+}
+
+# ---- System configuration ---------------------------------------------------
+
+configure_kali_rootfs() {
+  info "Configuring Kali chroot environment..."
+
+  # resolv.conf for DNS
+  cat > "$KALI_INSTALL_DIR/etc/resolv.conf" <<'EOF'
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+nameserver 1.1.1.1
+EOF
+
+  # hosts file
+  cat > "$KALI_INSTALL_DIR/etc/hosts" <<'EOF'
+127.0.0.1   localhost
+127.0.1.1   kali
+::1         localhost ip6-localhost ip6-loopback
+EOF
+
+  # hostname
+  echo "kali-tablet" > "$KALI_INSTALL_DIR/etc/hostname"
+
+  # profile additions for convenience
+  cat >> "$KALI_INSTALL_DIR/root/.bashrc" <<'EOF'
+
+# Kali tablet setup
+export TERM=xterm-256color
+export LANG=en_US.UTF-8
+alias ll='ls -la'
+alias cls='clear'
+# Start services if available
+[ -f /etc/init.d/ssh ] && service ssh start 2>/dev/null || true
+EOF
+
+  success "Kali rootfs configured"
+}
+
+# ---- Launch script ----------------------------------------------------------
+
+create_launch_script_proot() {
+  info "Creating proot launch script at $KALI_LAUNCH_SCRIPT ..."
+  cat > "$KALI_LAUNCH_SCRIPT" <<SCRIPT
+#!/usr/bin/env bash
+# Launch Kali Linux proot environment
+
+KALI_DIR="${KALI_INSTALL_DIR}"
+
+# Bind mounts
+BINDS=(
+  "-b" "/proc"
+  "-b" "/sys"
+  "-b" "/dev"
+  "-b" "/dev/pts"
+  "-b" "/sdcard"
+)
+
+# Handle --vnc: start VNC server inside Kali, then exit (do not enter shell)
+if [ "\${1:-}" = "--vnc" ]; then
+  proot \\
+    --link2symlink \\
+    -0 \\
+    -r "\${KALI_DIR}" \\
+    "\${BINDS[@]}" \\
+    -w /root \\
+    /usr/bin/env -i \\
+      HOME=/root \\
+      PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \\
+      TERM="\${TERM:-xterm-256color}" \\
+      LANG=C.UTF-8 \\
+      vncserver :1 -geometry 1280x800 -depth 24 -localhost no
+  echo "VNC running on \$(hostname -I | awk '{print \$1}'):5901"
+  echo "Change password with: kali vncpasswd"
+  exit 0
+fi
+
+# If a command was passed, execute it; otherwise start a shell
+CMD=("\${@:-/bin/bash --login}")
+
+exec proot \\
+  --link2symlink \\
+  -0 \\
+  -r "\${KALI_DIR}" \\
+  "\${BINDS[@]}" \\
+  -w /root \\
+  /usr/bin/env -i \\
+    HOME=/root \\
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \\
+    TERM="\${TERM:-xterm-256color}" \\
+    LANG=C.UTF-8 \\
+    "\${CMD[@]}"
+SCRIPT
+  chmod +x "$KALI_LAUNCH_SCRIPT"
+  success "Launch script created: run 'kali' in Termux to enter Kali"
+}
+
+create_launch_script_root() {
+  info "Creating native chroot launch script at $KALI_LAUNCH_SCRIPT ..."
+
+  # Ensure mount point directories exist inside the rootfs
+  for mp in proc sys dev dev/pts sdcard; do
+    mkdir -p "${KALI_INSTALL_DIR}/${mp}"
+  done
+
+  cat > "$KALI_LAUNCH_SCRIPT" <<SCRIPT
+#!/usr/bin/env bash
+# Launch Kali Linux native chroot (requires Magisk root)
+#
+# Usage:
+#   kali                     — interactive shell
+#   kali <cmd> [args...]     — run command and exit
+#   kali --stop              — unmount filesystems without entering chroot
+#
+# The script auto-unmounts on exit via a trap.
+
+KALI_DIR="${KALI_INSTALL_DIR}"
+
+# --- mount helper -----------------------------------------------------------
+
+kali_mount() {
+  su -c "
+    mkdir -p \${KALI_DIR}/{proc,sys,dev,dev/pts,sdcard,run}
+    mountpoint -q \${KALI_DIR}/proc    || mount -t proc  proc  \${KALI_DIR}/proc
+    mountpoint -q \${KALI_DIR}/sys     || mount -t sysfs sys   \${KALI_DIR}/sys
+    mountpoint -q \${KALI_DIR}/dev     || mount -o bind  /dev  \${KALI_DIR}/dev
+    mountpoint -q \${KALI_DIR}/dev/pts || mount -o bind  /dev/pts \${KALI_DIR}/dev/pts
+    mountpoint -q \${KALI_DIR}/sdcard  || mount -o bind  /sdcard  \${KALI_DIR}/sdcard
+  " 2>/dev/null
+}
+
+# --- unmount helper (best-effort, lazy fallback) ----------------------------
+
+kali_umount() {
+  su -c '
+    for mp in sdcard dev/pts dev sys proc run; do
+      mountpoint -q ${KALI_INSTALL_DIR}/\$mp && \
+        umount -l ${KALI_INSTALL_DIR}/\$mp 2>/dev/null || true
+    done
+  ' 2>/dev/null
+}
+
+# --- stop-only mode ---------------------------------------------------------
+
+if [ "\${1:-}" = "--stop" ]; then
+  echo "Unmounting Kali chroot filesystems..."
+  kali_umount && echo "Done." || echo "Nothing mounted or unmount failed."
+  exit 0
+fi
+
+# --- mount and enter --------------------------------------------------------
+
+kali_mount || { echo "Mount failed — is Magisk root active?"; exit 1; }
+
+# Trap ensures cleanup even on Ctrl-C or unexpected exit
+trap kali_umount EXIT INT TERM
+
+# Handle --vnc: start VNC server inside Kali, then exit (do not enter chroot shell)
+if [ "\${1:-}" = "--vnc" ]; then
+  su -c "chroot \${KALI_DIR} /usr/bin/env -i \\
+    HOME=/root \\
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \\
+    TERM=\${TERM:-xterm-256color} \\
+    LANG=C.UTF-8 \\
+    vncserver :1 -geometry 1280x800 -depth 24 -localhost no"
+  echo "VNC running on \$(hostname -I | awk '{print \$1}'):5901"
+  echo "Change password with: kali vncpasswd"
+  exit 0
+fi
+
+CMD=("\${@:-/bin/bash --login}")
+QUOTED_CMD=\$(printf '%q ' "\${CMD[@]}")
+
+su -c "chroot \${KALI_DIR} /usr/bin/env -i \\
+  HOME=/root \\
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \\
+  TERM=\${TERM:-xterm-256color} \\
+  LANG=C.UTF-8 \\
+  \${QUOTED_CMD}"
+SCRIPT
+  chmod +x "$KALI_LAUNCH_SCRIPT"
+
+  # kali-stop shortcut
+  cat > "$KALI_STOP_SCRIPT" <<STOP
+#!/usr/bin/env bash
+exec "${KALI_LAUNCH_SCRIPT}" --stop
+STOP
+  chmod +x "$KALI_STOP_SCRIPT"
+
+  success "Root chroot scripts created:"
+  success "  kali       — enter Kali (auto-mounts, auto-unmounts on exit)"
+  success "  kali-stop  — force unmount all Kali filesystems"
+}
+
+# ---- WiFi monitor mode (root only) -----------------------------------------
+
+setup_wifi_monitor() {
+  if ! $USE_ROOT; then
+    warn "--wifi-monitor requires --root (skipping)"
+    return
+  fi
+  info "Configuring WiFi monitor mode support..."
+
+  # Check for iw on the Android side
+  if ! su -c "which iw" &>/dev/null 2>&1; then
+    info "Installing iw in Termux (needed outside chroot for nl80211 control)..."
+    pkg install -y iw 2>/dev/null || \
+      warn "Could not install iw in Termux — install manually: pkg install iw"
+  fi
+
+  # Install aircrack-ng and iw inside Kali
+  mkdir -p "${KALI_INSTALL_DIR}/tmp"
+  local wifi_script="${KALI_INSTALL_DIR}/tmp/wifi-monitor-setup.sh"
+  cat > "$wifi_script" <<'INNER'
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y aircrack-ng iw wireless-tools rfkill
+# Confirm iw is available
+iw --version && echo "iw installed OK"
+INNER
+  chmod +x "$wifi_script"
+  su -c "chroot ${KALI_INSTALL_DIR} /bin/bash /tmp/wifi-monitor-setup.sh"
+  rm -f "$wifi_script"
+
+  # Append a wmon helper inside the chroot launch script
+  cat >> "$KALI_LAUNCH_SCRIPT" <<'SHORTCUT'
+
+# ---------------------------------------------------------------------------
+# WiFi monitor mode helpers (run inside Kali with: kali wmon <iface>)
+# These require root on the Android kernel. Adjust interface name as needed.
+# Common names on Mediatek: wlan0, wlan1  |  check with: ip link
+#
+# Enable:  kali wmon wlan0
+# Disable: kali wmon-off wlan0
+# List:    kali wmon-list
+# ---------------------------------------------------------------------------
+SHORTCUT
+
+  # Create wmon helper scripts inside the rootfs
+  cat > "${KALI_INSTALL_DIR}/usr/local/bin/wmon" <<'WMON'
+#!/bin/bash
+# Enable monitor mode on a WiFi interface
+# Usage: wmon <interface>  [channel]
+IFACE="${1:?Usage: wmon <interface> [channel]}"
+CHAN="${2:-}"
+ip link set "$IFACE" down
+iw dev "$IFACE" set type monitor
+ip link set "$IFACE" up
+[ -n "$CHAN" ] && iw dev "$IFACE" set channel "$CHAN"
+echo "Monitor mode enabled on $IFACE"
+iw dev "$IFACE" info
+WMON
+  chmod +x "${KALI_INSTALL_DIR}/usr/local/bin/wmon"
+
+  cat > "${KALI_INSTALL_DIR}/usr/local/bin/wmon-off" <<'WMON_OFF'
+#!/bin/bash
+# Disable monitor mode, restore managed mode
+# Usage: wmon-off <interface>
+IFACE="${1:?Usage: wmon-off <interface>}"
+ip link set "$IFACE" down
+iw dev "$IFACE" set type managed
+ip link set "$IFACE" up
+echo "Managed mode restored on $IFACE"
+WMON_OFF
+  chmod +x "${KALI_INSTALL_DIR}/usr/local/bin/wmon-off"
+
+  cat > "${KALI_INSTALL_DIR}/usr/local/bin/wmon-list" <<'WMON_LIST'
+#!/bin/bash
+# List wireless interfaces and their current modes
+iw dev 2>/dev/null || ip link show
+WMON_LIST
+  chmod +x "${KALI_INSTALL_DIR}/usr/local/bin/wmon-list"
+
+  success "WiFi monitor mode configured."
+  success "  Inside Kali: wmon wlan0 [channel]   — enable monitor mode"
+  success "              wmon-off wlan0           — restore managed mode"
+  success "              wmon-list                — list interfaces"
+  warn "Note: Monitor mode requires a WiFi chip that supports nl80211 monitor"
+  warn "      The Pritom Tab10's built-in RTL8188EU / Mediatek chip may not"
+  warn "      support monitor mode — an external USB WiFi adapter is recommended."
+}
+
+# ---- Optional: Kali security tools -----------------------------------------
+
+install_kali_tools() {
+  info "Installing Kali security tools (this may take 10-30 minutes)..."
+
+  mkdir -p "${KALI_INSTALL_DIR}/tmp"
+  local tool_script="${KALI_INSTALL_DIR}/tmp/install-tools.sh"
+  cat > "$tool_script" <<'INNER'
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+
+# Core tools
+apt-get install -y --no-install-recommends \
+  kali-tools-top10 \
+  nmap \
+  tcpdump \
+  wireshark-common \
+  tshark \
+  netcat-openbsd \
+  socat \
+  curl \
+  wget \
+  git \
+  python3 \
+  python3-pip \
+  openssh-server \
+  tmux \
+  vim
+
+# Clean up
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+INNER
+  chmod +x "$tool_script"
+
+  if $USE_ROOT; then
+    su -c "chroot ${KALI_INSTALL_DIR} /bin/bash /tmp/install-tools.sh"
+  else
+    proot --link2symlink -0 -r "$KALI_INSTALL_DIR" \
+      -b /proc -b /dev -b /sys \
+      /bin/bash /tmp/install-tools.sh
+  fi
+
+  rm -f "$tool_script"
+  success "Kali tools installed"
+}
+
+# ---- Optional: VNC server ---------------------------------------------------
+
+configure_vnc() {
+  info "Configuring VNC server inside Kali..."
+
+  local vnc_password
+  vnc_password=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c8)
+
+  mkdir -p "${KALI_INSTALL_DIR}/tmp"
+  local vnc_setup="${KALI_INSTALL_DIR}/tmp/vnc-setup.sh"
+  cat > "$vnc_setup" <<INNER
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y tigervnc-standalone-server xfce4 xfce4-terminal dbus-x11
+mkdir -p /root/.vnc
+echo "${vnc_password}" | vncpasswd -f > /root/.vnc/passwd
+chmod 600 /root/.vnc/passwd
+cat > /root/.vnc/xstartup <<'EOF'
+#!/bin/bash
+export DISPLAY=:1
+xrdb \$HOME/.Xresources 2>/dev/null || true
+startxfce4 &
+EOF
+chmod +x /root/.vnc/xstartup
+echo "VNC packages installed."
+INNER
+  chmod +x "$vnc_setup"
+
+  if $USE_ROOT; then
+    su -c "chroot ${KALI_INSTALL_DIR} /bin/bash /tmp/vnc-setup.sh"
+  else
+    proot --link2symlink -0 -r "$KALI_INSTALL_DIR" \
+      -b /proc -b /dev -b /sys \
+      /bin/bash /tmp/vnc-setup.sh
+  fi
+
+  rm -f "$vnc_setup"
+
+  success "VNC configured. Run 'kali --vnc' to start graphical desktop"
+  success "  VNC password: ${vnc_password}  (save this — change with 'kali vncpasswd')"
+}
+
+# ---- Main -------------------------------------------------------------------
+
+main() {
+  if $CHECK_ONLY; then
+    run_check
+    exit 0
+  fi
+
+  echo ""
+  echo -e "${BLUE}============================================${NC}"
+  echo -e "${BLUE}  Kali Linux NetHunter Setup               ${NC}"
+  echo -e "${BLUE}  Pritom Tab10 Max M10-R02 / Android 14    ${NC}"
+  echo -e "${BLUE}============================================${NC}"
+  echo ""
+
+  check_termux
+  check_storage
+  check_root
+
+  install_termux_deps
+
+  if [ -d "$KALI_INSTALL_DIR/usr" ]; then
+    warn "Kali rootfs already exists at $KALI_INSTALL_DIR"
+    read -rp "Re-download and overwrite? [y/N] " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+      rm -rf "$KALI_INSTALL_DIR"
+    else
+      info "Using existing rootfs"
+    fi
+  fi
+
+  if [ ! -d "$KALI_INSTALL_DIR/usr" ]; then
+    download_kali_rootfs
+  fi
+
+  configure_kali_rootfs
+
+  if $USE_ROOT; then
+    create_launch_script_root
+  else
+    create_launch_script_proot
+  fi
+
+  if $INSTALL_TOOLS; then
+    install_kali_tools
+  fi
+
+  if $INSTALL_VNC; then
+    configure_vnc
+  fi
+
+  if $SETUP_WIFI_MONITOR; then
+    setup_wifi_monitor
+  fi
+
+  echo ""
+  echo -e "${GREEN}============================================${NC}"
+  echo -e "${GREEN}  Setup complete!                          ${NC}"
+  echo -e "${GREEN}============================================${NC}"
+  echo ""
+  echo -e "  Enter Kali:        ${YELLOW}kali${NC}"
+  if $USE_ROOT; then
+  echo -e "  Unmount (cleanup): ${YELLOW}kali-stop${NC}"
+  fi
+  echo -e "  Install tools:     ${YELLOW}kali apt-get install kali-tools-top10${NC}"
+  if $INSTALL_VNC; then
+  echo -e "  Start desktop:     ${YELLOW}kali --vnc${NC}"
+  fi
+  echo -e "  Start SSH:         ${YELLOW}kali service ssh start${NC}"
+  if $SETUP_WIFI_MONITOR; then
+  echo -e "  Monitor mode:      ${YELLOW}kali wmon wlan1 6${NC}  (inside Kali)"
+  echo -e "  Restore managed:   ${YELLOW}kali wmon-off wlan1${NC}"
+  fi
+  echo ""
+  echo -e "  ${BLUE}Auto-start on boot:${NC} Install Termux:Boot from F-Droid, then:"
+  echo -e "    mkdir -p ~/.termux/boot"
+  # shellcheck disable=SC2028
+  echo -e "    echo 'kali service ssh start' > ~/.termux/boot/kali-boot.sh"
+  echo -e "    chmod +x ~/.termux/boot/kali-boot.sh"
+  echo ""
+  echo -e "  ${YELLOW}Legal:${NC} Use security tools only on systems you are authorized to test."
+  echo ""
+}
+
+main "$@"

--- a/docs/alpine-base-update.md
+++ b/docs/alpine-base-update.md
@@ -33,7 +33,7 @@ since the push out can be slow and require retries, we try to make all of the ch
 
 ### Preparation
 
-As a starting point you have to be on the update to date master branch
+As a starting point you have to be on the update to date main branch
 and be in the root directory of your local git clone. You should also
 have the same setup on all build machines used.
 

--- a/docs/platform-pritom-tablet.md
+++ b/docs/platform-pritom-tablet.md
@@ -1,0 +1,677 @@
+# LinuxKit on Pritom Tab10 Max M10-R02 (Android 14, ARM64)
+
+This document describes how to build and boot LinuxKit with Kali Linux security
+tools on the Pritom Tab10 Max M10-R02 tablet running Android 14.
+
+## Hardware Overview
+
+| Component   | Details                                  |
+|-------------|------------------------------------------|
+| Display     | 10.1" IPS, 1280×800                      |
+| CPU         | ARM64 (SoC vendor varies by batch)       |
+| RAM         | 4 GB                                     |
+| Storage     | 64 GB eMMC                               |
+| OS          | Android 14 (stock)                       |
+| Connectivity| WiFi 802.11 b/g/n, Bluetooth 5.0, USB-C |
+
+> **Note:** The M10-R02 revision may use different SoCs across production
+> batches (AllWinner, MediaTek, or Rockchip). Identify your exact chip with
+> `adb shell getprop ro.board.platform` before building a custom kernel.
+
+
+## Approach Options
+
+There are two practical ways to run LinuxKit with Kali tools on this tablet:
+
+### Option A: Native Boot (Full Linux, recommended for advanced users)
+
+Boot LinuxKit directly as the operating system after unlocking the bootloader.
+This requires complete replacement of Android and full hardware driver support.
+
+**Pros:** Full hardware access, best performance
+**Cons:** Requires unlocked bootloader, loses Android, complex kernel setup
+
+### Option B: Kali NetHunter Chroot (easier, Android preserved)
+
+Run Kali Linux inside Android via a chroot/proot environment using Termux.
+This does **not** use LinuxKit but achieves similar results with less effort
+and preserves your Android installation.
+
+**Pros:** No bootloader unlock needed, Android continues to work, faster setup
+**Cons:** Slightly reduced performance vs native, some kernel features restricted
+
+See [`contrib/android-kali/`](../contrib/android-kali/) for automated setup scripts.
+
+---
+
+## Option B: Kali NetHunter Chroot (Termux + proot)
+
+### Prerequisites
+
+- **Termux** from [F-Droid](https://f-droid.org/en/packages/com.termux/)
+  (the Google Play version is outdated and unsupported)
+- At least **4 GB** free internal storage (2 GB for minimal install)
+- Internet connection during initial setup
+- Optional: **Magisk** (root) for native chroot with full hardware access
+
+### Quick Setup
+
+Open Termux and run the automated setup script:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/marcelraschke/linuxkit/main/contrib/android-kali/nethunter-setup.sh \
+  | bash
+```
+
+Or copy the script from this repository and run locally:
+
+```bash
+bash contrib/android-kali/nethunter-setup.sh
+```
+
+Available options:
+
+```
+--check          Diagnose prerequisites without installing (arch, storage, root, network)
+--minimal        Download minimal rootfs (~200MB) instead of full (~1.5GB)
+--tools          Install kali-tools-top10 automatically
+--vnc            Set up VNC server + XFCE4 graphical desktop
+--root           Use native chroot (requires Magisk root)
+--wifi-monitor   Install wmon/wmon-off helpers for WiFi monitor mode (needs --root)
+```
+
+### Manual Setup
+
+If you prefer to set up manually:
+
+**Step 1: Install Termux dependencies**
+
+```bash
+pkg update && pkg install -y proot curl tar
+```
+
+**Step 2: Download the Kali ARM64 rootfs**
+
+```bash
+# Full install (~1.5GB)
+wget -O ~/kali-rootfs.tar.xz \
+  https://kali.download/nethunter-images/current/rootfs/kalifs-arm64-full.tar.xz
+
+# Minimal install (~200MB)
+wget -O ~/kali-rootfs.tar.xz \
+  https://kali.download/nethunter-images/current/rootfs/kalifs-arm64-minimal.tar.xz
+```
+
+**Step 3: Extract the rootfs**
+
+```bash
+mkdir -p ~/kali-arm64
+proot --link2symlink tar -xJf ~/kali-rootfs.tar.xz \
+  -C ~/kali-arm64 --exclude='dev'
+rm ~/kali-rootfs.tar.xz
+```
+
+**Step 4: Configure DNS and hostname**
+
+```bash
+echo -e "nameserver 8.8.8.8\nnameserver 1.1.1.1" > ~/kali-arm64/etc/resolv.conf
+echo "kali-tablet" > ~/kali-arm64/etc/hostname
+```
+
+**Step 5: Create a launch script**
+
+```bash
+cat > $PREFIX/bin/kali <<'EOF'
+#!/usr/bin/env bash
+exec proot --link2symlink -0 \
+  -r ~/kali-arm64 \
+  -b /proc -b /sys -b /dev -b /dev/pts \
+  -b /sdcard \
+  -w /root \
+  /usr/bin/env -i \
+    HOME=/root \
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    TERM="${TERM:-xterm-256color}" \
+    LANG=C.UTF-8 \
+    "${@:-/bin/bash --login}"
+EOF
+chmod +x $PREFIX/bin/kali
+```
+
+**Step 6: Enter Kali**
+
+```bash
+kali
+```
+
+### Installing Security Tools
+
+Inside the Kali proot environment:
+
+```bash
+# Update package lists
+apt-get update
+
+# Top 10 Kali tools (recommended starting point)
+apt-get install -y kali-tools-top10
+
+# Wireless security assessment tools
+apt-get install -y kali-tools-wireless
+
+# Web application testing
+apt-get install -y kali-tools-web
+
+# Individual tools
+apt-get install -y nmap tcpdump wireshark-cli netcat-openbsd \
+  metasploit-framework burpsuite sqlmap john hydra nikto \
+  aircrack-ng hashcat responder impacket-scripts
+```
+
+### SSH Access via USB Tethering
+
+USB tethering creates a direct Ethernet-over-USB link between the tablet and
+your computer — no WiFi or router required, lower latency, no firewall issues.
+
+**Step 1: Enable USB tethering on the tablet**
+
+1. Connect the tablet to your computer with a USB-C cable
+2. On the tablet: **Settings → Network & Internet → Hotspot & Tethering →
+   USB Tethering** → toggle ON
+3. Android assigns a private IP to both ends (typically `192.168.42.x`)
+
+**Step 2: Find the tablet's IP address**
+
+On the tablet in Termux:
+
+```bash
+# Show all IPv4 addresses; look for the usb0 or rndis0 interface
+ip -4 addr show
+
+# Example output:
+#   inet 192.168.42.129/24  (usb0)   ← tablet's USB IP
+```
+
+On your computer (to identify the interface):
+
+```bash
+# Linux / macOS
+ip route show | grep -E "192.168.42|usb|rndis"
+# or
+arp -n | grep -v incomplete
+
+# Windows (PowerShell)
+Get-NetIPAddress | Where-Object { $_.IPAddress -like "192.168.*" }
+```
+
+**Step 3: Start SSH inside Kali**
+
+```bash
+# Inside Kali (run 'kali' first in Termux)
+apt-get install -y openssh-server
+passwd root            # set a root password
+/usr/sbin/sshd -p 2222 -o "PermitRootLogin yes" -o "PasswordAuthentication yes"
+```
+
+**Step 4: Connect from your computer**
+
+```bash
+ssh -p 2222 root@192.168.42.129   # replace with tablet's actual IP
+```
+
+**Alternative: ADB port forward (no IP lookup needed)**
+
+If USB tethering is unavailable, use ADB to forward the SSH port:
+
+```bash
+# On your computer (tablet connected via USB, ADB enabled in Developer Options)
+adb forward tcp:2222 tcp:2222
+ssh -p 2222 root@127.0.0.1
+```
+
+**Tip:** Add the tablet to `~/.ssh/config` on your computer for convenience:
+
+```
+Host kali-tablet
+    HostName 192.168.42.129
+    Port 2222
+    User root
+    StrictHostKeyChecking no
+```
+
+Then simply: `ssh kali-tablet`
+
+### Graphical Desktop via VNC
+
+Install a lightweight desktop environment for graphical tools:
+
+```bash
+# Inside Kali
+apt-get install -y tigervnc-standalone-server xfce4 xfce4-terminal dbus-x11
+
+# Set VNC password
+vncpasswd
+
+# Start VNC server (tablet display is 1280×800)
+vncserver :1 -geometry 1280x800 -depth 24 -localhost no
+```
+
+Connect with a VNC client (e.g. RealVNC Viewer, TigerVNC) to `<tablet-ip>:5901`.
+
+To stop the VNC server:
+
+```bash
+vncserver -kill :1
+```
+
+### Auto-Start on Boot (Termux:Boot)
+
+Install [Termux:Boot](https://f-droid.org/en/packages/com.termux.boot/) from
+F-Droid to start Kali services automatically when the device powers on.
+
+**Step 1: Install and activate Termux:Boot**
+
+1. Install from F-Droid (not Google Play)
+2. Open the **Termux:Boot** app once — this registers it as a boot receiver
+3. You can close it immediately after
+
+**Step 2: Create a boot script**
+
+```bash
+mkdir -p ~/.termux/boot
+
+cat > ~/.termux/boot/kali-boot.sh <<'EOF'
+#!/data/data/com.termux/files/usr/bin/bash
+# Runs automatically after Android boot
+
+# Keep CPU awake during startup
+termux-wake-lock
+
+# Wait for Android to fully initialize networking
+sleep 10
+
+# Start Kali SSH server so the tablet is reachable over USB/WiFi
+kali service ssh start
+
+# Optional: start VNC (uncomment if --vnc was used)
+# kali vncserver :1 -geometry 1280x800 -depth 24 -localhost no
+EOF
+
+chmod +x ~/.termux/boot/kali-boot.sh
+```
+
+**Step 3: Verify**
+
+Reboot the tablet. After boot, open Termux and check:
+
+```bash
+kali service ssh status
+# Expected: sshd is running
+```
+
+**Notes:**
+- `termux-wake-lock` prevents Android from sleeping and killing the process;
+  install the companion app if the command is not found: `pkg install termux-api`
+- For root mode (`--root`), the boot script calls the same `kali` launcher
+  which auto-mounts and auto-unmounts; no special changes needed
+- Scripts in `~/.termux/boot/` run as the Termux user, not root — Magisk
+  grants root when `kali` calls `su` internally
+
+### Limitations of proot Mode
+
+Running without root (proot mode) has some restrictions:
+
+- **Raw sockets** limited — some network scanners need root privileges
+- **Kernel modules** cannot be loaded — e.g. no `monitor mode` for WiFi
+- **Device access** restricted — cannot directly open `/dev/rfkill`, USB raw devices
+- **iptables/nftables** require root on the Android kernel
+
+For full capabilities (including WiFi monitor mode and raw socket operations),
+use the `--root` flag with Magisk-rooted Android, or use
+[Option A](#option-a-native-linuxkit-boot) for native Linux boot.
+
+### Root Mode with Magisk
+
+Installing Magisk unlocks native chroot mode and full kernel access.
+
+**Step 1: Install Magisk**
+
+1. Obtain the stock boot image for your firmware version (from Pritom support or
+   community sources; do NOT flash images from other firmware versions)
+2. Patch it with the [Magisk app](https://github.com/topjohnwu/Magisk/releases)
+   on the tablet itself
+3. Boot to fastboot: hold **Power + Vol Down** ~10s (device-specific)
+4. Flash the patched boot image:
+   ```bash
+   fastboot flash boot magisk_patched_*.img
+   fastboot reboot
+   ```
+5. Open the Magisk app and complete setup
+
+**Step 2: Grant Termux root access**
+
+The first time Termux requests root, Magisk shows a popup. You can also
+pre-grant or manage access manually:
+
+1. Open the **Magisk** app
+2. Tap the **Superuser** tab (shield icon in the bottom navigation bar)
+3. **If Termux is already listed:** tap it and confirm the status is **Allow**
+4. **If Termux is not listed yet:**
+   - Open Termux and type `su` then press Enter
+   - A Magisk popup appears: tap **Grant**
+   - Check **Remember choice** so you are not prompted every session
+   - Termux now appears in the Superuser tab
+5. Verify the grant works — back in Termux:
+
+   ```bash
+   su -c "id"
+   # Expected output: uid=0(root) gid=0(root) groups=0(root) ...
+   ```
+
+**Troubleshooting the root grant:**
+
+| Symptom | Fix |
+|---------|-----|
+| Popup never appears | Swipe Termux away from recents, reopen it, try `su` again |
+| `su: permission denied` after grant | Restart the Magisk app; check the Superuser tab shows Allow (not Deny) |
+| Grant disappears after reboot | Open Magisk → Superuser → re-grant; enable **Persistent** mode if available |
+| "Magisk is not installed" on home screen | Boot image was overwritten by OTA — re-flash the patched `boot.img` |
+| Root works in Termux but not in script | Run `pkg install tsu` and use `tsu` instead of `su` as a workaround |
+
+**Step 3: Setup Kali with root chroot**
+
+```bash
+bash nethunter-setup.sh --root --tools
+```
+
+This uses native `chroot` instead of proot. The `kali` command:
+- Mounts `/proc`, `/sys`, `/dev`, `/dev/pts`, `/sdcard` via bind mounts
+- Enters the chroot with full root capabilities
+- **Auto-unmounts all filesystems on exit** (via shell trap)
+
+Force-unmount if needed (e.g. after a crash):
+
+```bash
+kali-stop
+```
+
+**Step 4: WiFi Monitor Mode (optional)**
+
+Requires a compatible WiFi adapter. The Pritom Tab10's built-in chipset typically
+does **not** support monitor mode — use an external USB WiFi adapter
+(e.g. Alfa AWUS036ACS, TP-Link TL-WN722N v1).
+
+Setup with the automated script:
+
+```bash
+bash nethunter-setup.sh --root --wifi-monitor
+```
+
+Or manually inside Kali:
+
+```bash
+# List interfaces
+wmon-list
+
+# Enable monitor mode on wlan1 (external USB adapter), channel 6
+wmon wlan1 6
+
+# Run airodump-ng
+airodump-ng wlan1
+
+# Restore managed mode
+wmon-off wlan1
+```
+
+**Comparison: proot vs root chroot**
+
+| Feature | proot (no root) | native chroot (Magisk) |
+|---------|-----------------|------------------------|
+| Setup difficulty | Easy | Medium (Magisk required) |
+| Raw sockets (nmap SYN scan) | No | Yes |
+| WiFi monitor mode | No | Yes (compatible adapter) |
+| iptables rules | No | Yes |
+| USB device access (/dev/bus) | No | Yes |
+| Performance | ~95% | ~99% |
+| Android OTA updates | Safe | Risk of losing root |
+
+---
+
+## Option A: Native LinuxKit Boot
+
+### Prerequisites
+
+- **Unlocked bootloader** — Required. The process varies by firmware version.
+  Check the Pritom support forum or XDA Developers for your specific firmware.
+- **ADB and fastboot** installed on your development machine
+- **Docker** with `buildx` and `--platform linux/arm64` support
+- **LinuxKit CLI** installed (`go install github.com/linuxkit/linuxkit/src/cmd/linuxkit@latest`)
+
+### Step 1: Identify Your SoC
+
+```bash
+adb shell getprop ro.board.platform
+adb shell cat /proc/cpuinfo | grep Hardware
+```
+
+Common results and their kernel configs:
+
+| `ro.board.platform` | SoC Family   | Kernel Config Needed          |
+|---------------------|--------------|-------------------------------|
+| `rk3566` / `rk3568` | Rockchip     | `CONFIG_ARCH_ROCKCHIP=y`      |
+| `mt8183` / `mt8168` | MediaTek     | `CONFIG_ARCH_MEDIATEK=y`      |
+| `sun50i*`           | AllWinner    | `CONFIG_ARCH_SUNXI=y`         |
+
+### Step 2: Build a Custom ARM64 Kernel
+
+The default `linuxkit/kernel:6.12.59` is a generic ARM64 server kernel.
+For the tablet you need to enable device-specific drivers.
+
+Clone the LinuxKit kernel config and modify:
+
+```bash
+cp kernel/6.12.x/config-aarch64 kernel/6.12.x/config-aarch64-tablet
+```
+
+Add or change these options in `config-aarch64-tablet`:
+
+```
+# Platform SoC (choose one based on your hardware)
+CONFIG_ARCH_ROCKCHIP=y      # for Rockchip RK35xx
+# CONFIG_ARCH_MEDIATEK=y    # for MediaTek MT8xxx
+# CONFIG_ARCH_SUNXI=y       # for AllWinner
+
+# Touchscreen support
+CONFIG_INPUT_TOUCHSCREEN=y
+CONFIG_TOUCHSCREEN_GOODIX=m   # Goodix GT911 (common on budget tablets)
+CONFIG_TOUCHSCREEN_ELAN=m     # ELAN touchscreens
+
+# Display / DRM (for graphical output beyond framebuffer)
+CONFIG_DRM=y
+CONFIG_DRM_PANFROST=m         # ARM Mali GPU driver (open source)
+
+# eMMC storage (MediaTek)
+CONFIG_MMC_MTK=m
+# eMMC storage (Rockchip)
+CONFIG_MMC_DW=m
+CONFIG_MMC_DW_ROCKCHIP=m
+
+# WiFi (common embedded chipsets)
+CONFIG_WLAN_VENDOR_MEDIATEK=y
+CONFIG_MT7921E=m              # MediaTek WiFi
+CONFIG_WLAN_VENDOR_REALTEK=y
+CONFIG_RTW88=m                # Realtek WiFi (alternative)
+
+# USB OTG / USB-C
+CONFIG_USB_DWC3=m
+CONFIG_USB_DWC3_OF_SIMPLE=m
+CONFIG_USB_ROLES_INTEL_XHCI=m
+```
+
+Build the custom kernel (requires Docker with arm64 support):
+
+```bash
+cd kernel
+make ARCH=aarch64 build_tag=6.12.x CONFIG=config-aarch64-tablet
+```
+
+### Step 3: Build the LinuxKit Image
+
+```bash
+linuxkit build \
+  -arch arm64 \
+  -format raw-efi \
+  examples/kali-pritom-tablet.yml
+```
+
+This produces `kali-pritom-tablet-efi.img`.
+
+### Step 4: Pre-build a Kali Tools Image (optional, for offline use)
+
+The default configuration pulls `kalilinux/kali-rolling:arm64` at boot time,
+which requires internet access. For offline use, build a custom image:
+
+```dockerfile
+# Dockerfile.kali-tablet
+FROM kalilinux/kali-rolling:arm64
+RUN apt-get update && apt-get install -y \
+    kali-tools-top10 \
+    kali-tools-wireless \
+    kali-tools-web \
+    nmap \
+    tcpdump \
+    wireshark-cli \
+    netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["/bin/bash", "-l"]
+```
+
+```bash
+docker buildx build \
+  --platform linux/arm64 \
+  -t my-kali-tablet:latest \
+  -f Dockerfile.kali-tablet \
+  --load .
+```
+
+Then update `kali-pritom-tablet.yml` to use `my-kali-tablet:latest` instead of
+`kalilinux/kali-rolling:arm64`.
+
+### Step 5: Flash and Boot
+
+#### Via fastboot (if bootloader supports standard fastboot):
+
+```bash
+fastboot boot kali-pritom-tablet-efi.img
+```
+
+#### Via USB booting / SD card:
+
+Some tablets support booting from a USB drive or SD card. Write the EFI image:
+
+```bash
+# Write to a USB drive or SD card (replace /dev/sdX)
+dd if=kali-pritom-tablet-efi.img of=/dev/sdX bs=4M status=progress
+```
+
+Then hold Volume Down during boot to select the USB/SD boot option.
+
+---
+
+## Networking
+
+### USB Tethering (recommended)
+
+Connect the tablet to your computer via USB-C and enable USB tethering in
+Android settings (before rebooting into LinuxKit). The DHCP client in the
+LinuxKit config will acquire an IP address automatically.
+
+### USB-to-Ethernet Adapter
+
+Attach a USB-C to Ethernet adapter. The kernel's `r8152` or `ax88179` driver
+covers most USB Ethernet adapters. Add a `modprobe` to the `onboot` section:
+
+```yaml
+onboot:
+  - name: usb-ethernet
+    image: linuxkit/modprobe:4248cdc3494779010e7e7488fc17b6fd45b73aeb
+    command: ["modprobe", "r8152"]
+```
+
+### WiFi
+
+WiFi requires a custom kernel with the correct driver for your tablet's WiFi
+chip. Identify the chip:
+
+```bash
+adb shell lsmod | grep -i wifi
+adb shell ls /sys/bus/sdio/devices/
+```
+
+---
+
+## Console Access
+
+LinuxKit boots with a framebuffer text console on the tablet display (`tty0`).
+Use a USB OTG adapter with a USB keyboard for interactive access.
+
+SSH access is also available once networking is configured. Add your SSH
+public key to `etc/ssh/authorized_keys` in the YAML `files` section.
+
+---
+
+## Limitations
+
+The default `linuxkit/kernel:6.12.59` does **not** support:
+
+- **Touchscreen** — `CONFIG_INPUT_TOUCHSCREEN` is disabled; requires custom kernel
+- **WiFi** — Most embedded WiFi chips need vendor-specific drivers
+- **GPU / DRM** — `CONFIG_DRM` is disabled; text console via framebuffer only
+- **Bluetooth** — Not compiled in for generic ARM64 server kernel
+- **Suspend/Resume** — Power management for mobile SoCs is not configured
+
+These limitations can be resolved by building a custom kernel as described in
+[Step 2](#step-2-build-a-custom-arm64-kernel) above. The LinuxKit kernel build
+infrastructure makes this straightforward — see [`kernels.md`](./kernels.md)
+for details.
+
+---
+
+## Kali Security Tools in the Container
+
+Once booted, access the Kali environment:
+
+```bash
+# From the getty terminal on the tablet display
+ctr run --rm --tty kalilinux/kali-rolling:arm64 kali /bin/bash
+
+# Or connect via SSH and exec into the running container
+ssh root@<tablet-ip>
+ctr task exec --exec-id kali kali-tools /bin/bash
+```
+
+Common Kali tools available in `kali-tools-top10`:
+
+| Tool         | Purpose                        |
+|--------------|--------------------------------|
+| `nmap`       | Network discovery and scanning |
+| `metasploit` | Penetration testing framework  |
+| `burpsuite`  | Web application proxy          |
+| `sqlmap`     | SQL injection testing          |
+| `john`       | Password cracking              |
+| `wireshark`  | Network packet analysis        |
+| `aircrack-ng`| WiFi security assessment       |
+| `netcat`     | Network utility                |
+| `hydra`      | Login brute-force testing      |
+| `nikto`      | Web server scanner             |
+
+> **Legal notice:** Only use security testing tools on networks and systems
+> for which you have explicit written authorization.
+
+---
+
+## See Also
+
+- [`kernels.md`](./kernels.md) — Building and customizing LinuxKit kernels
+- [`platform-rpi3.md`](./platform-rpi3.md) — Similar setup for Raspberry Pi 3b (ARM64)
+- [`../examples/kali-pritom-tablet.yml`](../examples/kali-pritom-tablet.yml) — Example YAML configuration

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,7 @@ clone (in my setup the official LinuxKit repository is available as
 `upstream` remote). If your setup is different, you may have to adjust
 some of the commands below.
 
-As a starting point you have to be on the update to date master branch
+As a starting point you have to be on the update to date main branch
 and be in the root directory of your local git clone. You should also
 have the same setup on all build machines used.
 

--- a/examples/kali-pritom-tablet.yml
+++ b/examples/kali-pritom-tablet.yml
@@ -1,0 +1,108 @@
+# LinuxKit configuration for Kali Linux security tools on Pritom Tab10 Max M10-R02
+# ARM64 Android tablet running Android 14
+#
+# Build with:
+#   linuxkit build -arch arm64 -format raw-efi examples/kali-pritom-tablet.yml
+#
+# Requirements:
+#   - Unlocked bootloader on the tablet
+#   - Custom ARM64 kernel with MediaTek/device-specific drivers (see docs/platform-pritom-tablet.md)
+#   - USB OTG adapter for keyboard/storage
+#
+# Note: The default linuxkit/kernel:6.12.59 is a generic ARM64 kernel.
+# For full hardware support (touchscreen, WiFi, eMMC), a custom kernel build
+# targeting your tablet's SoC is required. See docs/platform-pritom-tablet.md.
+
+kernel:
+  image: linuxkit/kernel:6.12.59
+  cmdline: "console=tty0 console=ttyAMA0 rootwait panic=10 quiet"
+  ucode: ""
+
+init:
+  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
+  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
+
+onboot:
+  - name: sysctl
+    image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6
+  # Enable IP forwarding for network pivoting during assessments
+  - name: sysctl-security
+    image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6
+    binds:
+      - /etc/sysctl.d:/etc/sysctl.d
+  # Load USB storage driver for external drives/USB sticks
+  - name: usb-storage
+    image: linuxkit/modprobe:4248cdc3494779010e7e7488fc17b6fd45b73aeb
+    command: ["modprobe", "usb_storage"]
+  # Acquire IP via DHCP (USB tethering or USB-to-Ethernet adapter)
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+
+services:
+  # Interactive terminal on the display console
+  - name: getty
+    image: linuxkit/getty:a86d74c8f89be8956330c3b115b0b1f2e09ef6e0
+    env:
+      - INSECURE=true
+    binds:
+      - /dev:/dev
+    devices:
+      - path: all
+        type: c
+  # Random number generator daemon
+  - name: rngd
+    image: linuxkit/rngd:984eb580ecb63986f07f626b61692a97aacd7198
+  # SSH daemon for remote access over USB tethering or network
+  - name: sshd
+    image: linuxkit/sshd:08e5d4a46603eff485d5d1b14001cc932a530858
+    binds:
+      - /etc/resolv.conf:/etc/resolv.conf
+      - /etc/ssh/authorized_keys:/root/.ssh/authorized_keys
+  # Kali Linux rolling release with top 10 security tools
+  # Build a custom image with pre-installed tools for offline use:
+  #   docker buildx build --platform linux/arm64 -t my-kali-tools -f Dockerfile.kali .
+  - name: kali-tools
+    image: kalilinux/kali-rolling:arm64
+    capabilities:
+      - CAP_NET_ADMIN
+      - CAP_NET_RAW
+      - CAP_SYS_ADMIN
+      - CAP_SYS_PTRACE
+      - CAP_SYS_CHROOT
+      - CAP_SETUID
+      - CAP_SETGID
+      - CAP_DAC_OVERRIDE
+      - CAP_AUDIT_WRITE
+      - CAP_NET_BIND_SERVICE
+    net: host
+    pid: host
+    binds:
+      - /etc/resolv.conf:/etc/resolv.conf
+      - /var/kali-data:/root
+    mounts:
+      - type: bind
+        source: /proc
+        destination: /proc
+        options:
+          - rbind
+    command: ["/bin/bash", "-c", "exec /bin/bash -l"]
+
+files:
+  - path: etc/linuxkit-config
+    metadata: yaml
+  # sysctl settings for security testing
+  - path: etc/sysctl.d/99-kali-tablet.conf
+    contents: |
+      # Enable IP forwarding for network assessments
+      net.ipv4.ip_forward=1
+      net.ipv6.conf.all.forwarding=1
+      # Allow raw socket operations
+      net.ipv4.ping_group_range=0 2147483647
+  # Placeholder for SSH authorized keys - replace with your public key
+  - path: etc/ssh/authorized_keys
+    contents: |
+      # Add your SSH public key here, e.g.:
+      # ssh-ed25519 AAAA... user@host

--- a/writeups/dashboard/index.html
+++ b/writeups/dashboard/index.html
@@ -6,7 +6,7 @@
   <title>AI Cy8er Command Center | EotW CTF SS CASE IT 2025</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body data-page="index" data-depth="0">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="js/data.js"></script>
   <script src="js/app.js"></script>
-  <script>
-    buildNav('index');
-    buildFooter();
-    renderOverview();
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/js/app.js
+++ b/writeups/dashboard/js/app.js
@@ -1,16 +1,17 @@
+// Path prefix from the page's depth relative to the dashboard root.
+// Overview (index.html) is depth 0; category pages under pages/ are depth 1.
+function rootPrefix() {
+  const depth = parseInt(document.body.dataset.depth || '0', 10);
+  return '../'.repeat(depth);
+}
+
 function buildNav(activePage) {
   const nav = document.getElementById('main-nav');
+  const prefix = rootPrefix();
   const links = [
     { href: 'index.html', label: 'Overview', id: 'index' },
-    ...CATEGORIES.map(c => ({
-      href: `pages/${c.id}.html`,
-      label: c.name,
-      id: c.id
-    }))
+    ...CATEGORIES.map(c => ({ href: `pages/${c.id}.html`, label: c.name, id: c.id }))
   ];
-
-  const isSubpage = location.pathname.includes('/pages/');
-  const prefix = isSubpage ? '../' : '';
 
   nav.innerHTML = `
     <div class="nav-inner">
@@ -24,17 +25,15 @@ function buildNav(activePage) {
 }
 
 function buildFooter() {
-  const footer = document.getElementById('main-footer');
-  footer.innerHTML = `AI Cy8er Command Center &mdash; EotW CTF SS CASE IT 2025`;
+  document.getElementById('main-footer').innerHTML =
+    `AI Cy8er Command Center &mdash; EotW CTF SS CASE IT 2025`;
 }
 
 function renderOverview() {
   const stats = getStats();
-  const app = document.getElementById('app');
-
   const solveRate = stats.total > 0 ? Math.round((stats.solved / stats.total) * 100) : 0;
 
-  app.innerHTML = `
+  document.getElementById('app').innerHTML = `
     <div class="hero">
       <h1>AI Cy8er Command Center</h1>
       <div class="subtitle">EotW CTF &bull; SS CASE IT 2025</div>
@@ -79,9 +78,9 @@ function renderCategoryPage(catId) {
   const cat = CATEGORIES.find(c => c.id === catId);
   if (!cat) return;
 
+  const prefix = rootPrefix();
   const challenges = getChallengesByCategory(catId);
   const app = document.getElementById('app');
-
   const diffClass = d => `badge badge-${d.toLowerCase()}`;
 
   if (challenges.length === 0) {
@@ -100,12 +99,15 @@ function renderCategoryPage(catId) {
     return;
   }
 
+  const solved = challenges.filter(c => c.solved).length;
+  const points = challenges.filter(c => c.solved).reduce((s, c) => s + c.points, 0);
+
   app.innerHTML = `
     <div class="page-header">
       <div class="page-icon">${cat.icon}</div>
       <div>
         <h1>${cat.name}</h1>
-        <p>${challenges.filter(c=>c.solved).length}/${challenges.length} solved &bull; ${challenges.filter(c=>c.solved).reduce((s,c)=>s+c.points,0)} pts</p>
+        <p>${solved}/${challenges.length} solved &bull; ${points} pts</p>
       </div>
     </div>
     <table class="challenge-table">
@@ -128,9 +130,21 @@ function renderCategoryPage(catId) {
             </td>
             <td><span class="points">${ch.points}</span></td>
             <td><span class="${diffClass(ch.difficulty)}">${ch.difficulty}</span></td>
-            <td>${ch.writeup ? `<a href="${ch.writeup}" class="writeup-link">[View]</a>` : '<span style="color:var(--text-muted)">--</span>'}</td>
+            <td>${ch.writeup ? `<a href="${prefix}${ch.writeup}" class="writeup-link">[View]</a>` : '<span style="color:var(--text-muted)">--</span>'}</td>
           </tr>
         `).join('')}
       </tbody>
     </table>`;
+}
+
+// Single entry point: each page sets <body data-page="..."> and calls initDashboard().
+function initDashboard() {
+  const page = document.body.dataset.page;
+  buildNav(page === 'index' ? 'index' : page);
+  buildFooter();
+  if (page === 'index') {
+    renderOverview();
+  } else {
+    renderCategoryPage(page);
+  }
 }

--- a/writeups/dashboard/js/data.js
+++ b/writeups/dashboard/js/data.js
@@ -23,6 +23,8 @@ const CHALLENGES = [
     points: 500,
     difficulty: "Hard",
     solved: true,
+    // Path is relative to the dashboard root (writeups/dashboard/); the
+    // renderer prepends the page-depth prefix so it resolves from any page.
     writeup: "../forensics/ai-command-center.md",
     summary: "Forensic analysis of an AI command and control infrastructure."
   }

--- a/writeups/dashboard/pages/crypto.html
+++ b/writeups/dashboard/pages/crypto.html
@@ -6,7 +6,7 @@
   <title>Cryptography | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="crypto" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('crypto');
-    buildFooter();
-    renderCategoryPage('crypto');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/forensics.html
+++ b/writeups/dashboard/pages/forensics.html
@@ -6,7 +6,7 @@
   <title>Forensics | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="forensics" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('forensics');
-    buildFooter();
-    renderCategoryPage('forensics');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/misc.html
+++ b/writeups/dashboard/pages/misc.html
@@ -6,7 +6,7 @@
   <title>Miscellaneous | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="misc" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('misc');
-    buildFooter();
-    renderCategoryPage('misc');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/osint.html
+++ b/writeups/dashboard/pages/osint.html
@@ -6,7 +6,7 @@
   <title>OSINT | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="osint" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('osint');
-    buildFooter();
-    renderCategoryPage('osint');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/pwn.html
+++ b/writeups/dashboard/pages/pwn.html
@@ -6,7 +6,7 @@
   <title>Binary Exploitation | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="pwn" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('pwn');
-    buildFooter();
-    renderCategoryPage('pwn');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/reversing.html
+++ b/writeups/dashboard/pages/reversing.html
@@ -6,7 +6,7 @@
   <title>Reverse Engineering | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="reversing" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('reversing');
-    buildFooter();
-    renderCategoryPage('reversing');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/stego.html
+++ b/writeups/dashboard/pages/stego.html
@@ -6,7 +6,7 @@
   <title>Steganography | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="stego" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('stego');
-    buildFooter();
-    renderCategoryPage('stego');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>

--- a/writeups/dashboard/pages/web.html
+++ b/writeups/dashboard/pages/web.html
@@ -6,7 +6,7 @@
   <title>Web Exploitation | AI Cy8er Command Center</title>
   <link rel="stylesheet" href="../css/style.css">
 </head>
-<body>
+<body data-page="web" data-depth="1">
   <div class="scanline"></div>
   <nav id="main-nav"></nav>
   <div class="container" id="app"></div>
@@ -14,10 +14,6 @@
 
   <script src="../js/data.js"></script>
   <script src="../js/app.js"></script>
-  <script>
-    buildNav('web');
-    buildFooter();
-    renderCategoryPage('web');
-  </script>
+  <script>initDashboard();</script>
 </body>
 </html>


### PR DESCRIPTION
**- What I did**

Consolidates three previously-proposed feature sets onto a single branch:

1. **Kali Linux support for Pritom Tab10 Max** (was PR #79) — added `docs/platform-pritom-tablet.md` (Option A native LinuxKit boot + Option B Kali NetHunter chroot via Termux), `examples/kali-pritom-tablet.yml` (ARM64 config), and `contrib/android-kali/{README.md,nethunter-setup.sh,kali-boot.sh}`.
2. **CTF dashboard broken-writeup-link fix + page-init refactor** (was PR #84) — the dashboard base already lives in `master`, but the writeup link was still broken. Writeup paths are now stored relative to the dashboard root and the renderer prepends a depth-based prefix, so links resolve from both the overview and category pages. Replaced the duplicated per-page inline scripts with a single `initDashboard()` entry point; each page declares context via `<body data-page … data-depth …>`.
3. **master → main migration for CI and docs** (was PR #85 / #86) — `publish.yaml` now triggers on `main` only, `package_release.yml` comments updated to "merge-to-main", and the "up to date master branch" line in `docs/releasing.md` / `docs/alpine-base-update.md` changed to "main branch".

**- How I did it**

Files for the unmerged suggestions were restored byte-for-byte from the original PR head branches (blob SHAs verified identical). The doc/workflow text edits reproduce the exact diffs from PR #85 / #86. The remaining `master` references in the release docs point to the **upstream** `linuxkit/linuxkit` repository (`git push upstream …`), so they were intentionally left unchanged — matching the original PRs.

⚠️ **Caveat:** The repository default branch is still `master`. Once `publish.yaml` triggers on `main` only, the Packages Push workflow no longer fires for merges to `master`. This matches PR #85 exactly, but assumes the default branch is subsequently switched to `main` (a repo-settings change an admin must make). The other workflows (`ci.yml`, `release.yml`) have no branch filter and are unaffected.

**- How to verify it**

- `bash -n contrib/android-kali/nethunter-setup.sh` and `bash -n contrib/android-kali/kali-boot.sh` — syntax OK
- YAML parses for `examples/kali-pritom-tablet.yml`, `.github/workflows/publish.yaml`, `.github/workflows/package_release.yml`
- `node --check` on `writeups/dashboard/js/app.js` and `data.js`
- From `writeups/dashboard/pages/` the writeup link resolves to `writeups/forensics/ai-command-center.md`, which exists on disk

**- Description for the changelog**

Add Kali Pritom Tab10 Max support, fix CTF dashboard writeup link, and migrate CI/docs from master to main.

**- A picture of a cute animal (not mandatory but encouraged)**

🦦

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgY9Bb5A5u1Jzbx6ziViBv)_