### PR TITLE
contrib/android-kali: fix `kali` with no args failing to launch a shell

### DIFF
--- a/contrib/android-kali/nethunter-setup.sh
+++ b/contrib/android-kali/nethunter-setup.sh
@@ -376,8 +376,14 @@ if [ "\${1:-}" = "--vnc" ]; then
   exit 0
 fi
 
-# If a command was passed, execute it; otherwise start a shell
-CMD=("\${@:-/bin/bash --login}")
+# If a command was passed, execute it; otherwise start a login shell.
+# A quoted \${@:-default} does not word-split, so an empty \$@ would try to
+# exec "/bin/bash --login" as one filename. Build the default as an array.
+if [ "\$#" -eq 0 ]; then
+  CMD=(/bin/bash --login)
+else
+  CMD=("\$@")
+fi
 
 exec proot \\
   --link2symlink \\
@@ -469,7 +475,11 @@ if [ "\${1:-}" = "--vnc" ]; then
   exit 0
 fi
 
-CMD=("\${@:-/bin/bash --login}")
+if [ "\$#" -eq 0 ]; then
+  CMD=(/bin/bash --login)
+else
+  CMD=("\$@")
+fi
 QUOTED_CMD=\$(printf '%q ' "\${CMD[@]}")
 
 su -c "chroot \${KALI_DIR} /usr/bin/env -i \\


### PR DESCRIPTION
**- What I did**

Fixed a real bug in the Kali NetHunter launch scripts generated by `contrib/android-kali/nethunter-setup.sh`: running the `kali` command with **no arguments** — the primary "enter a shell" use case — failed to start a shell in both proot and root chroot modes.

**- How I did it**

Both generated launch scripts built the command to run as:

```sh
CMD=("${@:-/bin/bash --login}")
```

A quoted `${@:-default}` does **not** word-split its default value, so when `$@` is empty the array collapses to a single element `/bin/bash --login` (with the space embedded). `env -i … "${CMD[@]}"` then tries to exec a file literally named `/bin/bash --login`, which doesn't exist → the shell never launches.

Replaced it with an explicit array-valued default in both `create_launch_script_proot` and `create_launch_script_root`:

```sh
if [ "$#" -eq 0 ]; then
  CMD=(/bin/bash --login)
else
  CMD=("$@")
fi
```

Passing an explicit command (e.g. `kali nmap …`, and everything `kali-boot.sh` does) was never affected and still works.

**- How to verify it**

- `bash -n contrib/android-kali/nethunter-setup.sh` — syntax OK
- `shellcheck contrib/android-kali/nethunter-setup.sh` — clean (was already clean; stays clean)
- Rendered both generated launch scripts with a stubbed `PREFIX` and confirmed: no-args now yields two argv elements (`/bin/bash`, `--login`); an explicit command passes through unchanged; both generated scripts are valid bash and shellcheck-clean.

**- Description for the changelog**

Fix `kali` launcher failing to open a shell when run without arguments (android-kali contrib).

**- A picture of a cute animal (not mandatory but encouraged)**

🦎

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgY9Bb5A5u1Jzbx6ziViBv)_